### PR TITLE
Fix/server side

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,14 @@ React component that provides device information (browser, cpu, device, engine, 
 
 ## Installation
 
+#### npm
 ```sh
-$ npm install react-device
+$ npm install react-device --save
+```
+
+#### yarn
+```sh
+$ yarn add react-device
 ```
 
 ## API

--- a/es/Device.js
+++ b/es/Device.js
@@ -29,7 +29,7 @@ function _possibleConstructorReturn(self, call) { if (!self) { throw new Referen
 
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
-var SIZE_UNKNOWN = exports.SIZE_UNKNOWN = -1;
+var SIZE_UNKNOWN = exports.SIZE_UNKNOWN = null;
 var LANDSCAPE = exports.LANDSCAPE = 'landscape';
 var PORTRAIT = exports.PORTRAIT = 'portrait';
 
@@ -62,8 +62,13 @@ var Device = function (_Component) {
   }, {
     key: '_onChange',
     value: function _onChange() {
+      Device._publish(Device._listeners);
+    }
+  }, {
+    key: '_publish',
+    value: function _publish(listeners) {
       var deviceInfo = Device._buildDeviceInfo();
-      Device._listeners.forEach(function (listener) {
+      listeners.forEach(function (listener) {
         listener(deviceInfo);
       });
     }
@@ -75,6 +80,10 @@ var Device = function (_Component) {
     var _this = _possibleConstructorReturn(this, (Device.__proto__ || Object.getPrototypeOf(Device)).call(this, props));
 
     Device.details = (0, _uaParserJs2.default)(props.userAgent);
+    if (!Device._debouncedChange) {
+      Device._debouncedChange = (0, _debounce2.default)(Device._onChange, Device.DEBOUNCE_TIME);
+    }
+    Device._publish([props.onChange]);
     return _this;
   }
 
@@ -82,11 +91,9 @@ var Device = function (_Component) {
     key: 'componentDidMount',
     value: function componentDidMount() {
       if (!Device._listeners.length) {
-        Device._debouncedChange = (0, _debounce2.default)(Device._onChange, Device.DEBOUNCE_TIME);
         window.addEventListener('resize', Device._debouncedChange, true);
       }
       Device._listeners.push(this.props.onChange);
-      Device._debouncedChange();
     }
   }, {
     key: 'componentWillUnmount',
@@ -121,7 +128,7 @@ var Device = function (_Component) {
 }(_react.Component);
 
 Device._listeners = [];
-Device.DEBOUNCE_TIME = 100;
+Device.DEBOUNCE_TIME = 250;
 Device.details = {};
 
 

--- a/lib/Device.js
+++ b/lib/Device.js
@@ -27,7 +27,7 @@ function _possibleConstructorReturn(self, call) { if (!self) { throw new Referen
 
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
-var SIZE_UNKNOWN = exports.SIZE_UNKNOWN = -1;
+var SIZE_UNKNOWN = exports.SIZE_UNKNOWN = null;
 var LANDSCAPE = exports.LANDSCAPE = 'landscape';
 var PORTRAIT = exports.PORTRAIT = 'portrait';
 
@@ -60,8 +60,13 @@ var Device = function (_Component) {
   }, {
     key: '_onChange',
     value: function _onChange() {
+      Device._publish(Device._listeners);
+    }
+  }, {
+    key: '_publish',
+    value: function _publish(listeners) {
       var deviceInfo = Device._buildDeviceInfo();
-      Device._listeners.forEach(function (listener) {
+      listeners.forEach(function (listener) {
         listener(deviceInfo);
       });
     }
@@ -73,6 +78,10 @@ var Device = function (_Component) {
     var _this = _possibleConstructorReturn(this, (Device.__proto__ || Object.getPrototypeOf(Device)).call(this, props));
 
     Device.details = (0, _uaParserJs2.default)(props.userAgent);
+    if (!Device._debouncedChange) {
+      Device._debouncedChange = (0, _debounce2.default)(Device._onChange, Device.DEBOUNCE_TIME);
+    }
+    Device._publish([props.onChange]);
     return _this;
   }
 
@@ -80,11 +89,9 @@ var Device = function (_Component) {
     key: 'componentDidMount',
     value: function componentDidMount() {
       if (!Device._listeners.length) {
-        Device._debouncedChange = (0, _debounce2.default)(Device._onChange, Device.DEBOUNCE_TIME);
         window.addEventListener('resize', Device._debouncedChange, true);
       }
       Device._listeners.push(this.props.onChange);
-      Device._debouncedChange();
     }
   }, {
     key: 'componentWillUnmount',
@@ -119,7 +126,7 @@ var Device = function (_Component) {
 }(_react.Component);
 
 Device._listeners = [];
-Device.DEBOUNCE_TIME = 100;
+Device.DEBOUNCE_TIME = 250;
 Device.details = {};
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-device",
-  "version": "0.5.3",
+  "version": "0.6.0",
   "description": "React aware device information",
   "keywords": [
     "react",

--- a/src/device.js
+++ b/src/device.js
@@ -2,7 +2,7 @@ import React, { Component, PropTypes } from 'react'
 import debounce from 'lodash/debounce'
 import parser from 'ua-parser-js'
 
-export const SIZE_UNKNOWN = -1
+export const SIZE_UNKNOWN = null
 export const LANDSCAPE = 'landscape'
 export const PORTRAIT = 'portrait'
 
@@ -34,28 +34,34 @@ class Device extends Component {
   }
 
   static _onChange() {
+    Device._publish(Device._listeners)
+  }
+
+  static _publish(listeners) {
     const deviceInfo = Device._buildDeviceInfo()
-    Device._listeners.forEach(listener => {
+    listeners.forEach(listener => {
       listener(deviceInfo)
     })
   }
 
   static _listeners = []
-  static DEBOUNCE_TIME = 100
+  static DEBOUNCE_TIME = 250
   static details = {}
 
   constructor (props) {
     super(props)
     Device.details = parser(props.userAgent)
+    if (!Device._debouncedChange) {
+      Device._debouncedChange = debounce(Device._onChange, Device.DEBOUNCE_TIME)
+    }
+    Device._publish([props.onChange])
   }
 
   componentDidMount () {
     if (!Device._listeners.length) {
-      Device._debouncedChange = debounce(Device._onChange, Device.DEBOUNCE_TIME)
       window.addEventListener('resize', Device._debouncedChange, true)
     }
     Device._listeners.push(this.props.onChange)
-    Device._debouncedChange()
   }
 
   componentWillUnmount () {


### PR DESCRIPTION
Move calling onChange from `componentDidMount` to constructor since `componentDidMount` is not called on server.

Split the static `_onChange` into 2 methods 
- `_onChange`: used to register for window events
- `_publish`: used to call the listeners

By splitting this out, I can call `_publish` in the constructor for a single `onChange` prop.

Also change the default `width` and `height` from `-1` to `null`.