### PR TITLE
fix: initial client side call incorrect

### DIFF
--- a/lib/device.js
+++ b/lib/device.js
@@ -31,6 +31,10 @@ var SIZE_UNKNOWN = exports.SIZE_UNKNOWN = null;
 var LANDSCAPE = exports.LANDSCAPE = 'landscape';
 var PORTRAIT = exports.PORTRAIT = 'portrait';
 
+var isClientSide = function isClientSide() {
+  return typeof window != 'undefined' && window.document;
+};
+
 /**
  *
  */
@@ -47,7 +51,7 @@ var Device = function (_Component) {
         orientation: LANDSCAPE
       };
 
-      if (global.window) {
+      if (isClientSide()) {
         windowDetails.width = window.innerWidth || document.documentElement.clientWidth || document.body.clientWidth;
         windowDetails.height = window.innerHeight || document.documentElement.clientHeight || document.body.clientHeight;
         windowDetails.orientation = windowDetails.width > windowDetails.height ? LANDSCAPE : PORTRAIT;
@@ -81,17 +85,31 @@ var Device = function (_Component) {
     if (!Device._debouncedChange) {
       Device._debouncedChange = (0, _debounce2.default)(Device._onChange, Device.DEBOUNCE_TIME);
     }
-    Device._publish([props.onChange]);
+    // componentDidMount is not called on server so we load device information
+    // here if on the server; client side loading will happen in componentDidMount
+    // after rendering so we know the document is loaded
+    if (!isClientSide()) {
+      Device._publish([props.onChange]);
+    }
     return _this;
   }
 
   _createClass(Device, [{
     key: 'componentDidMount',
     value: function componentDidMount() {
+      var _this2 = this;
+
       if (!Device._listeners.length) {
         window.addEventListener('resize', Device._debouncedChange, true);
       }
       Device._listeners.push(this.props.onChange);
+      if (isClientSide()) {
+        // at his point, its possible that the viewport meta tag (if one on page)
+        // has not adjusted the innerWidth/innerHeight values, so delay briefly
+        setTimeout(function () {
+          Device._publish([_this2.props.onChange]);
+        }, 1);
+      }
     }
   }, {
     key: 'componentWillUnmount',


### PR DESCRIPTION
The initial client side call must be done in `componentDidMount` (after
a small delay to allow meta viewport to update the
innerWidth/innerHeight values.

Since `componentDidMount` is not called on server side, need to still do
the initial call in constructor on server